### PR TITLE
Bug.MDD141 - Wrong common name in the certificate after installation

### DIFF
--- a/2.4.97-debian/.gitlab-ci.yml
+++ b/2.4.97-debian/.gitlab-ci.yml
@@ -2,3 +2,11 @@ build 2.4.97-debian:
   extends: .build
   variables:
     VERSION: "2.4.97-debian"
+
+test 2.4.97-debian:
+  extends: .test
+  variables:
+    VERSION: "2.4.97-debian"
+  only:
+    changes:
+    - 2.4.97-debian/*

--- a/2.4.97-debian/files/entrypoint_apache.sh
+++ b/2.4.97-debian/files/entrypoint_apache.sh
@@ -9,6 +9,8 @@ MISP_APP_CONFIG_PATH=$MISP_APP_PATH/Config
 MISP_CONFIG=$MISP_APP_CONFIG_PATH/config.php
 DATABASE_CONFIG=$MISP_APP_CONFIG_PATH/database.php
 EMAIL_CONFIG=$MISP_APP_CONFIG_PATH/email.php
+SSL_CERT="/etc/apache2/ssl/cert.pem"
+SSL_KEY="/etc/apache2/ssl/key.pem"
 FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MISP/app/Plugin/CakeResque/Config /var/www/MISP/app/Config /var/www/MISP/.gnupg /var/www/MISP/.smime /etc/apache2/ssl"
 # defaults
 [ -z $MYSQL_HOST ] && export MYSQL_HOST=localhost
@@ -246,9 +248,11 @@ function setup_via_cake_cli(){
 
 function create_ssl_cert(){
     # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
-    sudo openssl req -newkey rsa:4096 -days 3650 -nodes -x509 \
-    -subj "/C=${OPENSSL_C}/ST=${OPENSSL_ST}/L=${OPENSSL_L}/O=${OPENSSL_O}/OU=${OPENSSL_OU}/CN=${NAME}/emailAddress=${OPENSSL_EMAILADDRESS}" \
-    -keyout /etc/apache2/ssl/key.pem -out /etc/apache2/ssl/cert.pem
+    while [ -f $PID_CERT_CREATER ]
+    do
+        echo "`date +%T` -  misp-proxy container create currently the certificate. misp-server wait until misp-proxy is finish."
+    done
+    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER
 }
 
 function check_mysql(){

--- a/2.4.98-debian/.gitlab-ci.yml
+++ b/2.4.98-debian/.gitlab-ci.yml
@@ -2,3 +2,11 @@ build 2.4.98-debian:
   extends: .build
   variables:
     VERSION: "2.4.98-debian"
+
+test 2.4.98-debian:
+  extends: .test
+  variables:
+    VERSION: "2.4.98-debian"
+  only:
+    changes:
+    - 2.4.98-debian/*

--- a/2.4.98-debian/files/entrypoint_apache.sh
+++ b/2.4.98-debian/files/entrypoint_apache.sh
@@ -9,6 +9,8 @@ MISP_APP_CONFIG_PATH=$MISP_APP_PATH/Config
 MISP_CONFIG=$MISP_APP_CONFIG_PATH/config.php
 DATABASE_CONFIG=$MISP_APP_CONFIG_PATH/database.php
 EMAIL_CONFIG=$MISP_APP_CONFIG_PATH/email.php
+SSL_CERT="/etc/apache2/ssl/cert.pem"
+SSL_KEY="/etc/apache2/ssl/key.pem"
 FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MISP/app/Plugin/CakeResque/Config /var/www/MISP/app/Config /var/www/MISP/.gnupg /var/www/MISP/.smime /etc/apache2/ssl"
 # defaults
 [ -z $MYSQL_HOST ] && export MYSQL_HOST=localhost
@@ -244,12 +246,16 @@ function setup_via_cake_cli(){
     #curl --header "Authorization: $AUTH_KEY" --header "Accept: application/json" --header "Content-Type: application/json" -k -X POST https://127.0.0.1/objectTemplates/update
 }
 
+
 function create_ssl_cert(){
     # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
-    sudo openssl req -newkey rsa:4096 -days 3650 -nodes -x509 \
-    -subj "/C=${OPENSSL_C}/ST=${OPENSSL_ST}/L=${OPENSSL_L}/O=${OPENSSL_O}/OU=${OPENSSL_OU}/CN=${NAME}/emailAddress=${OPENSSL_EMAILADDRESS}" \
-    -keyout /etc/apache2/ssl/key.pem -out /etc/apache2/ssl/cert.pem
+    while [ -f $PID_CERT_CREATER ]
+    do
+        echo "`date +%T` -  misp-proxy container create currently the certificate. misp-server wait until misp-proxy is finish."
+    done
+    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER
 }
+
 
 function check_mysql(){
     # Test when MySQL is ready

--- a/2.4.99-debian/.gitlab-ci.yml
+++ b/2.4.99-debian/.gitlab-ci.yml
@@ -8,3 +8,6 @@ test 2.4.99-debian:
   extends: .test
   variables:
     VERSION: "2.4.99-debian"
+  only:
+    changes:
+    - 2.4.99-debian/*

--- a/2.4.99-debian/files/entrypoint_apache.sh
+++ b/2.4.99-debian/files/entrypoint_apache.sh
@@ -9,6 +9,8 @@ MISP_APP_CONFIG_PATH=$MISP_APP_PATH/Config
 MISP_CONFIG=$MISP_APP_CONFIG_PATH/config.php
 DATABASE_CONFIG=$MISP_APP_CONFIG_PATH/database.php
 EMAIL_CONFIG=$MISP_APP_CONFIG_PATH/email.php
+SSL_CERT="/etc/apache2/ssl/cert.pem"
+SSL_KEY="/etc/apache2/ssl/key.pem"
 FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MISP/app/Plugin/CakeResque/Config /var/www/MISP/app/Config /var/www/MISP/.gnupg /var/www/MISP/.smime /etc/apache2/ssl"
 # defaults
 [ -z $MYSQL_HOST ] && export MYSQL_HOST=localhost
@@ -246,9 +248,11 @@ function setup_via_cake_cli(){
 
 function create_ssl_cert(){
     # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
-    sudo openssl req -newkey rsa:4096 -days 3650 -nodes -x509 \
-    -subj "/C=${OPENSSL_C}/ST=${OPENSSL_ST}/L=${OPENSSL_L}/O=${OPENSSL_O}/OU=${OPENSSL_OU}/CN=${NAME}/emailAddress=${OPENSSL_EMAILADDRESS}" \
-    -keyout /etc/apache2/ssl/key.pem -out /etc/apache2/ssl/cert.pem
+    while [ -f $PID_CERT_CREATER ]
+    do
+        echo "`date +%T` -  misp-proxy container create currently the certificate. misp-server wait until misp-proxy is finish."
+    done
+    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER
 }
 
 function check_mysql(){


### PR DESCRIPTION
## Changelog for bug.MDD141 - Wrong common name in the certificate after installation### Update  
We have changed the existing container versions to fix the false common name in the certificate.

### General changes
No general changes were made.

### Corrections & Improvements
- Change Version 2.4.97-debian
- Change Version 2.4.98-debian
- Change Version 2.4.99-debian

### Detailed changes
- We have modified the Entrypoint script so that the common name is now the same as the FQDN hostname. 
- We have adapted the gitlab-ci test job so that it will now only be executed if something has changed on this container. Otherwise the testjob will not be executed.