### PR TITLE
Changelog for bug.MDD143 - Fix for function "create_certificate" deadlock Bug

### DIFF
--- a/2.4.97-debian/files/entrypoint_apache.sh
+++ b/2.4.97-debian/files/entrypoint_apache.sh
@@ -12,6 +12,8 @@ EMAIL_CONFIG=$MISP_APP_CONFIG_PATH/email.php
 SSL_CERT="/etc/apache2/ssl/cert.pem"
 SSL_KEY="/etc/apache2/ssl/key.pem"
 FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MISP/app/Plugin/CakeResque/Config /var/www/MISP/app/Config /var/www/MISP/.gnupg /var/www/MISP/.smime /etc/apache2/ssl"
+PID_CERT_CREATER="/etc/apache2/ssl/SSL_create.pid"
+
 # defaults
 [ -z $MYSQL_HOST ] && export MYSQL_HOST=localhost
 [ -z $MYSQL_USER ] && export MYSQL_USER=misp
@@ -19,6 +21,9 @@ FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MIS
 [ -z $SENDER_ADDRESS ] && export SENDER_ADDRESS=`hostname`
 [ -z $MISP_SALT ] && MISP_SALT="$(</dev/urandom tr -dc A-Za-z0-9 | head -c 50)"
 [ -z $CAKE ] && export CAKE="$MISP_APP_PATH/Console/cake"
+
+
+
 
 function init_pgp(){
     echo "####################################"
@@ -248,11 +253,12 @@ function setup_via_cake_cli(){
 
 function create_ssl_cert(){
     # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
-    while [ -f $PID_CERT_CREATER ]
+    while [ -f $PID_CERT_CREATER.proxy ]
     do
         echo "`date +%T` -  misp-proxy container create currently the certificate. misp-server wait until misp-proxy is finish."
+        sleep 2
     done
-    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER
+    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER.server && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER.server
 }
 
 function check_mysql(){

--- a/2.4.98-debian/files/entrypoint_apache.sh
+++ b/2.4.98-debian/files/entrypoint_apache.sh
@@ -12,6 +12,8 @@ EMAIL_CONFIG=$MISP_APP_CONFIG_PATH/email.php
 SSL_CERT="/etc/apache2/ssl/cert.pem"
 SSL_KEY="/etc/apache2/ssl/key.pem"
 FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MISP/app/Plugin/CakeResque/Config /var/www/MISP/app/Config /var/www/MISP/.gnupg /var/www/MISP/.smime /etc/apache2/ssl"
+PID_CERT_CREATER="/etc/apache2/ssl/SSL_create.pid"
+
 # defaults
 [ -z $MYSQL_HOST ] && export MYSQL_HOST=localhost
 [ -z $MYSQL_USER ] && export MYSQL_USER=misp
@@ -19,6 +21,9 @@ FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MIS
 [ -z $SENDER_ADDRESS ] && export SENDER_ADDRESS=`hostname`
 [ -z $MISP_SALT ] && MISP_SALT="$(</dev/urandom tr -dc A-Za-z0-9 | head -c 50)"
 [ -z $CAKE ] && export CAKE="$MISP_APP_PATH/Console/cake"
+
+
+
 
 function init_pgp(){
     echo "####################################"
@@ -249,11 +254,12 @@ function setup_via_cake_cli(){
 
 function create_ssl_cert(){
     # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
-    while [ -f $PID_CERT_CREATER ]
+    while [ -f $PID_CERT_CREATER.proxy ]
     do
         echo "`date +%T` -  misp-proxy container create currently the certificate. misp-server wait until misp-proxy is finish."
+        sleep 2
     done
-    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER
+    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER.server && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER.server
 }
 
 

--- a/2.4.99-debian/files/entrypoint_apache.sh
+++ b/2.4.99-debian/files/entrypoint_apache.sh
@@ -12,6 +12,8 @@ EMAIL_CONFIG=$MISP_APP_CONFIG_PATH/email.php
 SSL_CERT="/etc/apache2/ssl/cert.pem"
 SSL_KEY="/etc/apache2/ssl/key.pem"
 FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MISP/app/Plugin/CakeResque/Config /var/www/MISP/app/Config /var/www/MISP/.gnupg /var/www/MISP/.smime /etc/apache2/ssl"
+PID_CERT_CREATER="/etc/apache2/ssl/SSL_create.pid"
+
 # defaults
 [ -z $MYSQL_HOST ] && export MYSQL_HOST=localhost
 [ -z $MYSQL_USER ] && export MYSQL_USER=misp
@@ -19,6 +21,9 @@ FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MIS
 [ -z $SENDER_ADDRESS ] && export SENDER_ADDRESS=`hostname`
 [ -z $MISP_SALT ] && MISP_SALT="$(</dev/urandom tr -dc A-Za-z0-9 | head -c 50)"
 [ -z $CAKE ] && export CAKE="$MISP_APP_PATH/Console/cake"
+
+
+
 
 function init_pgp(){
     echo "####################################"
@@ -248,11 +253,12 @@ function setup_via_cake_cli(){
 
 function create_ssl_cert(){
     # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
-    while [ -f $PID_CERT_CREATER ]
+    while [ -f $PID_CERT_CREATER.proxy ]
     do
         echo "`date +%T` -  misp-proxy container create currently the certificate. misp-server wait until misp-proxy is finish."
+        sleep 2
     done
-    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER
+    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER.server && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/CN=${HOSTNAME}" -nodes && echo "finished." && rm $PID_CERT_CREATER.server
 }
 
 function check_mysql(){


### PR DESCRIPTION
## Changelog for bug.MDD143 - Fix for function "create_certificate" deadlock Bug
### Update Informations 
Proxy version 1.4-alpine creates a file to prevent the misp-server from creating its own certificate. This should be deleted once the creation is complete. Unfortunately the proxy with verison 1.4-alpine interrupted the script before removing the file. Therefore it has not been deleted anymore. Since only one file was used for both the proxy and the misp-server this bug has the consequence that the apache2 entrypoint of the misp-server version 2.4.97-2.4.99 is also deadlocked.

### General Changes
No general changes were made.

### Fixes & Improvements
- Added on the misp-server 2.4.97-2.4.99 a own pid file for misp-server and misp-proxy.

### Detailed Changes
- We have added an additional pid file. So we now have one that creates the misp-proxy and queries the misp-server and one that is created by the misp-server and queries the misp-proxy. Its own file can overwrite both the proxy and the server. Therefore such deadlocks should be a thing of the past in the future.