### PR TITLE
Bug.MDD143 - Fix for function "create_certificate" deadlock Bug

### DIFF
--- a/2.4.97-debian/files/entrypoint_apache.sh
+++ b/2.4.97-debian/files/entrypoint_apache.sh
@@ -338,6 +338,10 @@ function upgrade(){
     done
 }
 
+
+##############   MAIN   #################
+echo "wait 30 seconds for DB" && sleep 30
+
 # If a customer needs a analze column in misp
 echo "check if analyze column should be added..."
     [ "$ADD_ANALYZE_COLUMN" == "yes" ] && add_analyze_column

--- a/2.4.97-debian/files/healthcheck.sh
+++ b/2.4.97-debian/files/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function check_apache(){
-    curl -f https://localhost/ || exit 1
+    curl -fk https://localhost/ || exit 1
 }
 
 function check_mysql(){

--- a/2.4.98-debian/files/entrypoint_apache.sh
+++ b/2.4.98-debian/files/entrypoint_apache.sh
@@ -340,6 +340,9 @@ function upgrade(){
     done
 }
 
+##############   MAIN   #################
+echo "wait 30 seconds for DB" && sleep 30
+
 # If a customer needs a analze column in misp
 echo "check if analyze column should be added..."
     [ "$ADD_ANALYZE_COLUMN" == "yes" ] && add_analyze_column

--- a/2.4.98-debian/files/healthcheck.sh
+++ b/2.4.98-debian/files/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function check_apache(){
-    curl -f https://localhost/ || exit 1
+    curl -fk https://localhost/ || exit 1
 }
 
 function check_mysql(){

--- a/2.4.98-debian/files/supervisord.conf
+++ b/2.4.98-debian/files/supervisord.conf
@@ -43,7 +43,7 @@ stderr_logfile_maxbytes=0
 # autostart=true
 
 [program:cron]
-command=/cron.sh
+command=/entrypoint_cron.sh
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/2.4.99-debian/files/entrypoint_apache.sh
+++ b/2.4.99-debian/files/entrypoint_apache.sh
@@ -338,6 +338,11 @@ function upgrade(){
     done
 }
 
+##############   MAIN   #################
+echo "wait 30 seconds for DB" && sleep 30
+
+
+
 # If a customer needs a analze column in misp
 echo "check if analyze column should be added..."
     [ "$ADD_ANALYZE_COLUMN" == "yes" ] && add_analyze_column

--- a/2.4.99-debian/files/healthcheck.sh
+++ b/2.4.99-debian/files/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function check_apache(){
-    curl -f https://localhost/ || exit 1
+    curl -fk https://localhost/ || exit 1
 }
 
 function check_mysql(){

--- a/2.4.99-debian/files/supervisord.conf
+++ b/2.4.99-debian/files/supervisord.conf
@@ -43,7 +43,7 @@ stderr_logfile_maxbytes=0
 # autostart=true
 
 [program:cron]
-command=/cron.sh
+command=/entrypoint_cron.sh
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
## Changelog for bug.MDD143 - Fix for function "create_certificate" deadlock Bug
### Update Informations 
Proxy version 1.4-alpine creates a file to prevent the misp-server from creating its own certificate. This should be deleted once the creation is complete. Unfortunately the proxy with verison 1.4-alpine interrupted the script before removing the file. Therefore it has not been deleted anymore. Since only one file was used for both the proxy and the misp-server this bug has the consequence that the apache2 entrypoint of the misp-server version 2.4.97-2.4.99 is also deadlocked.

### General Changes
No general changes were made.

### Fixes & Improvements
- Added on the misp-server 2.4.97-2.4.99 a own pid file for misp-server and misp-proxy.

### Detailed Changes
- We have added an additional pid file. So we now have one that creates the misp-proxy and queries the misp-server and one that is created by the misp-server and queries the misp-proxy. Its own file can overwrite both the proxy and the server. Therefore such deadlocks should be a thing of the past in the future.