### PR TITLE
Bug.MDD146 - Fixing Bugs in entrypoint_apache.sh for MISP-Server 2.4.97-2.4.99

### DIFF
--- a/2.4.97-debian/files/entrypoint_apache.sh
+++ b/2.4.97-debian/files/entrypoint_apache.sh
@@ -4,9 +4,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 STARTMSG="[ENTRYPOINT_APACHE]"
 
-export MISP_FQDN=$HOSTNAME
-PGP_ENABLE=0
-SMIME_ENABLE=0
 MISP_BASE_PATH=/var/www/MISP
 MISP_APP_PATH=/var/www/MISP/app
 MISP_APP_CONFIG_PATH=$MISP_APP_PATH/Config
@@ -20,11 +17,15 @@ FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MIS
 PID_CERT_CREATER="/etc/apache2/ssl/SSL_create.pid"
 
 # defaults
+
+[ -z $MISP_FQDN ] && export MISP_FQDN="https://$HOSTNAME"
+[ -z $PGP_ENABLE ] && export PGP_ENABLE=0
+[ -z $SMIME_ENABLE ] && export SMIME_ENABLE=0
 [ -z $MYSQL_HOST ] && export MYSQL_HOST=localhost
 [ -z $MYSQL_USER ] && export MYSQL_USER=misp
 [ -z $MISP_FQDN ] && export MISP_FQDN=`hostname -f`
 [ -z $SENDER_ADDRESS ] && export SENDER_ADDRESS="no-reply@$MISP_FQDN"
-[ -z $MISP_SALT ] && MISP_SALT="$(</dev/urandom tr -dc A-Za-z0-9 | head -c 50)"
+[ -z $MISP_SALT ] && export MISP_SALT="$(</dev/urandom tr -dc A-Za-z0-9 | head -c 50)"
 [ -z $CAKE ] && export CAKE="$MISP_APP_PATH/Console/cake"
 
 
@@ -101,7 +102,8 @@ function init_misp_config(){
     sed -i "s/db\s*password/$MYSQL_PASSWORD/" $DATABASE_CONFIG
 
     echo "$STARTMSG Configure MISP | Set MISP-Url in config.php"
-    sed -i "s/.*baseurl.*=>.*,/    'baseurl' => '$MISP_FQDN',/" $MISP_CONFIG
+    sed -i "s_.*baseurl.*=>.*_    \'baseurl\' => \'$MISP_FQDN\',_" $MISP_CONFIG
+    sudo $CAKE baseurl "$MISP_FQDN"
 
     echo "$STARTMSG Configure MISP | Set Email in config.php"
     sed -i "s/email@address.com/$SENDER_ADDRESS/" $MISP_CONFIG
@@ -126,6 +128,7 @@ function setup_via_cake_cli(){
     #sudo -E $CAKE userInit -q
     #AUTH_KEY=$(mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -h $MYSQL_HOST $MYSQL_DATABASE -e "SELECT authkey FROM users;" | head -2| tail -1)
     # Setup some more MISP default via cake CLI
+    sudo $CAKE baseurl "$MISP_FQDN"
     # Tune global time outs
     sudo $CAKE Admin setSetting "Session.autoRegenerate" 0
     sudo $CAKE Admin setSetting "Session.timeout" 600
@@ -382,7 +385,7 @@ echo "$STARTMSG check if HTTPS MISP config should be enabled..."
     [ -f /etc/apache2/ssl/cert.pem -a ! -f /etc/apache2/sites-enabled/misp.ssl.conf ] && mv /etc/apache2/sites-enabled/misp.ssl /etc/apache2/sites-enabled/misp.ssl.conf
 
 echo "$STARTMSG check if HTTP MISP config should be disabled..."
-    [ -f /etc/apache2/ssl/cert.pem -a -f /etc/apache2/sites-enabled/misp.http ] && mv /etc/apache2/sites-enabled/misp.conf /etc/apache2/sites-enabled/misp.http
+    [ -f /etc/apache2/ssl/cert.pem -a ! -f /etc/apache2/sites-enabled/misp.http ] && mv /etc/apache2/sites-enabled/misp.conf /etc/apache2/sites-enabled/misp.http
 
 ##### check MySQL
 echo "$STARTMSG check if MySQL is ready..." && check_mysql

--- a/2.4.98-debian/files/entrypoint_apache.sh
+++ b/2.4.98-debian/files/entrypoint_apache.sh
@@ -4,9 +4,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 STARTMSG="[ENTRYPOINT_APACHE]"
 
-export MISP_FQDN=$HOSTNAME
-PGP_ENABLE=0
-SMIME_ENABLE=0
 MISP_BASE_PATH=/var/www/MISP
 MISP_APP_PATH=/var/www/MISP/app
 MISP_APP_CONFIG_PATH=$MISP_APP_PATH/Config
@@ -20,11 +17,15 @@ FOLDER_with_VERSIONS="/var/www/MISP/app/tmp /var/www/MISP/app/files /var/www/MIS
 PID_CERT_CREATER="/etc/apache2/ssl/SSL_create.pid"
 
 # defaults
+
+[ -z $MISP_FQDN ] && export MISP_FQDN="https://$HOSTNAME"
+[ -z $PGP_ENABLE ] && export PGP_ENABLE=0
+[ -z $SMIME_ENABLE ] && export SMIME_ENABLE=0
 [ -z $MYSQL_HOST ] && export MYSQL_HOST=localhost
 [ -z $MYSQL_USER ] && export MYSQL_USER=misp
 [ -z $MISP_FQDN ] && export MISP_FQDN=`hostname -f`
 [ -z $SENDER_ADDRESS ] && export SENDER_ADDRESS="no-reply@$MISP_FQDN"
-[ -z $MISP_SALT ] && MISP_SALT="$(</dev/urandom tr -dc A-Za-z0-9 | head -c 50)"
+[ -z $MISP_SALT ] && export MISP_SALT="$(</dev/urandom tr -dc A-Za-z0-9 | head -c 50)"
 [ -z $CAKE ] && export CAKE="$MISP_APP_PATH/Console/cake"
 
 
@@ -101,7 +102,8 @@ function init_misp_config(){
     sed -i "s/db\s*password/$MYSQL_PASSWORD/" $DATABASE_CONFIG
 
     echo "$STARTMSG Configure MISP | Set MISP-Url in config.php"
-    sed -i "s/.*baseurl.*=>.*,/    'baseurl' => '$MISP_FQDN',/" $MISP_CONFIG
+    sed -i "s_.*baseurl.*=>.*_    \'baseurl\' => \'$MISP_FQDN\',_" $MISP_CONFIG
+    sudo $CAKE baseurl "$MISP_FQDN"
 
     echo "$STARTMSG Configure MISP | Set Email in config.php"
     sed -i "s/email@address.com/$SENDER_ADDRESS/" $MISP_CONFIG
@@ -126,6 +128,7 @@ function setup_via_cake_cli(){
     #sudo -E $CAKE userInit -q
     #AUTH_KEY=$(mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -h $MYSQL_HOST $MYSQL_DATABASE -e "SELECT authkey FROM users;" | head -2| tail -1)
     # Setup some more MISP default via cake CLI
+    sudo $CAKE baseurl "$MISP_FQDN"
     # Tune global time outs
     sudo $CAKE Admin setSetting "Session.autoRegenerate" 0
     sudo $CAKE Admin setSetting "Session.timeout" 600
@@ -382,7 +385,7 @@ echo "$STARTMSG check if HTTPS MISP config should be enabled..."
     [ -f /etc/apache2/ssl/cert.pem -a ! -f /etc/apache2/sites-enabled/misp.ssl.conf ] && mv /etc/apache2/sites-enabled/misp.ssl /etc/apache2/sites-enabled/misp.ssl.conf
 
 echo "$STARTMSG check if HTTP MISP config should be disabled..."
-    [ -f /etc/apache2/ssl/cert.pem -a -f /etc/apache2/sites-enabled/misp.http ] && mv /etc/apache2/sites-enabled/misp.conf /etc/apache2/sites-enabled/misp.http
+    [ -f /etc/apache2/ssl/cert.pem -a ! -f /etc/apache2/sites-enabled/misp.http ] && mv /etc/apache2/sites-enabled/misp.conf /etc/apache2/sites-enabled/misp.http
 
 ##### check MySQL
 echo "$STARTMSG check if MySQL is ready..." && check_mysql

--- a/2.4.99-debian/Dockerfile
+++ b/2.4.99-debian/Dockerfile
@@ -67,6 +67,7 @@ rsyslog \
 ARG LANG=en_US.UTF-8
 RUN locale-gen ${LANG}
 ENV LANG ${LANG}
+ENV LC_ALL ${LANG}
 ENV LANGUAGE=en_US:en
 #ENV LC_ALL ${LANG}
 
@@ -162,6 +163,14 @@ ENV LANGUAGE=en_US:en
         RUN apt-get install -y python3-dev python3-pip libxml2-dev libxslt1-dev zlib1g-dev python-setuptools
         # Upgrade
         #RUN pip3 install setuptools --upgrade;
+        # install mixbox to accomodate the new STIX dependencies:
+        RUN cd /var/www/MISP/app/files/scripts; \
+            git clone https://github.com/CybOXProject/mixbox.git; \
+            cd mixbox; python3 setup.py install;
+        # install python-maec
+        RUN cd /var/www/MISP/app/files/scripts; \
+            git clone https://github.com/MAECProject/python-maec.git; \
+            cd python-maec; python3 setup.py install;
         # install python-cybox
         RUN cd /var/www/MISP/app/files/scripts; \
             git clone https://github.com/CybOXProject/python-cybox.git; \
@@ -170,14 +179,6 @@ ENV LANGUAGE=en_US:en
         RUN cd /var/www/MISP/app/files/scripts; \
             git clone https://github.com/STIXProject/python-stix.git; \
             cd python-stix; python3 setup.py install;
-        # install mixbox to accomodate the new STIX dependencies:
-        RUN cd /var/www/MISP/app/files/scripts; \
-            git clone https://github.com/CybOXProject/mixbox.git; \
-            cd mixbox; python3 setup.py install;
-        # install python-maec
-        RUN cd /var/www/MISP/app/files/scripts; \
-            git clone https://github.com/MAECProject/python-maec.git; \
-            cd mixbox; python3 setup.py install;
 
     
     # install PyMISP

--- a/2.4.99-debian/files/entrypoint_apache.sh
+++ b/2.4.99-debian/files/entrypoint_apache.sh
@@ -102,7 +102,8 @@ function init_misp_config(){
     sed -i "s/db\s*password/$MYSQL_PASSWORD/" $DATABASE_CONFIG
 
     echo "$STARTMSG Configure MISP | Set MISP-Url in config.php"
-    sed -i "s/.*baseurl.*=>.*/    'baseurl' => '$MISP_FQDN',/" $MISP_CONFIG
+    sed -i "s_.*baseurl.*=>.*_    \'baseurl\' => \'$MISP_FQDN\',_" $MISP_CONFIG
+    sudo $CAKE baseurl "$MISP_FQDN"
 
     echo "$STARTMSG Configure MISP | Set Email in config.php"
     sed -i "s/email@address.com/$SENDER_ADDRESS/" $MISP_CONFIG

--- a/2.4.99-debian/files/etc/apache2/sites-enabled/misp.ssl
+++ b/2.4.99-debian/files/etc/apache2/sites-enabled/misp.ssl
@@ -2,9 +2,10 @@
   ServerName misp-server
   DocumentRoot /var/www/MISP/app/webroot
   <Directory /var/www/MISP/app/webroot>
-          Options -Indexes
-          AllowOverride all
-          Require all granted
+    Options -Indexes
+    AllowOverride all
+    Order allow,deny
+    allow from all
   </Directory>
 
   SSLEngine On
@@ -23,6 +24,6 @@
   CustomLog /var/log/apache2/access.log combined
 
   ServerSignature Off
-  Header set X-Content-Type-Options nosniff
-  Header set X-Frame-Options DENY
+  #Header set X-Content-Type-Options nosniff
+  #Header set X-Frame-Options DENY
 </VirtualHost>


### PR DESCRIPTION
## Changelog for bug.MDD146 - Fixing Bugs in entrypoint_apache.sh for MISP-Server 2.4.97-2.4.9b
### Update Informations 
The entrypoint_apache.sh script takes care of the settings of apache2 and the basic settings of MISP itself. However, there were bugs regarding the baseurl. This was not set correctly. This caused the browsers to report an error after logging in. It said that the page was endlessly redirected.

### General Changes
No general changes were made.

### Fixes & Improvements
- Fixed an Bug in entrypoint_apache.sh script and in the Dockerfile

### Detailed Changes
- We have changed the order in the dockerfile for the git dependencies of MISP.
- We have changed the baseurl sed command to set it up in config.php and in the cake settings.
- We have changed the apache2 configuration.