### PR TITLE
Bug.MDD148 - Fixing Bugs in entrypoint scripts for MISP-Server 2.4.97-99

### DIFF
--- a/2.4.97-debian/files/entrypoint_cron.sh
+++ b/2.4.97-debian/files/entrypoint_cron.sh
@@ -8,10 +8,7 @@ CAKE="/var/www/MISP/app/Console/cake"
 
 
 # SLEEP 1h
-sleep 3600
-
-
-pushd /var/www/MISP/app
+sleep 1800
 
 [ -z $AUTH_KEY ] && export AUTH_KEY=$(mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE -e "SELECT authkey FROM users;" | head -2|tail -1)
 
@@ -48,13 +45,13 @@ do
     #If you would like to automate tasks such as caching feeds or pulling from server instances, you can do it using the following command line tools. Simply execute the given commands via the command line / create cron jobs easily out of them.:
     #Pull: MISP/app/Console/cake Server pull [user_id] [server_id] [full|update]
 
-    echo "$STARTMSG $CAKE Server pull 1 update..." && $CAKE Server pull 1 update
+    echo "$STARTMSG $CAKE Server pull 1 update..." && sudo -u www-data $CAKE Server pull 1
 
     # CacheFeed: MISP/app/Console/cake Server cacheFeed [user_id] [feed_id|all|csv|text|misp]
-    echo "$STARTMSG $CAKE Server cacheFeed 1 all..." && $CAKE Server cacheFeed 1 all
+    echo "$STARTMSG $CAKE Server cacheFeed 1 all..." && sudo -u www-data  $CAKE Server cacheFeed 1 all
 
     #FetchFeed: MISP/app/Console/cake Server fetchFeed [user_id] [feed_id|all|csv|text|misp]
-    echo "$STARTMSG $CAKE Server fetchFeed 1 all..." && $CAKE Server fetchFeed 1 all
+    echo "$STARTMSG $CAKE Server fetchFeed 1 all..." && sudo -u www-data  $CAKE Server fetchFeed 1 all
     # Finished
     echo "$STARTMSG [ $COUNTER ] Finished MISP-dockerized Cronjob at `date +%Y-%m-%d_%H:%M`... "
     sleep 3600

--- a/2.4.98-debian/files/entrypoint_cron.sh
+++ b/2.4.98-debian/files/entrypoint_cron.sh
@@ -8,10 +8,7 @@ CAKE="/var/www/MISP/app/Console/cake"
 
 
 # SLEEP 1h
-sleep 3600
-
-
-pushd /var/www/MISP/app
+sleep 1800
 
 [ -z $AUTH_KEY ] && export AUTH_KEY=$(mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE -e "SELECT authkey FROM users;" | head -2|tail -1)
 
@@ -48,13 +45,13 @@ do
     #If you would like to automate tasks such as caching feeds or pulling from server instances, you can do it using the following command line tools. Simply execute the given commands via the command line / create cron jobs easily out of them.:
     #Pull: MISP/app/Console/cake Server pull [user_id] [server_id] [full|update]
 
-    echo "$STARTMSG $CAKE Server pull 1 update..." && $CAKE Server pull 1 update
+    echo "$STARTMSG $CAKE Server pull 1 update..." && sudo -u www-data $CAKE Server pull 1
 
     # CacheFeed: MISP/app/Console/cake Server cacheFeed [user_id] [feed_id|all|csv|text|misp]
-    echo "$STARTMSG $CAKE Server cacheFeed 1 all..." && $CAKE Server cacheFeed 1 all
+    echo "$STARTMSG $CAKE Server cacheFeed 1 all..." && sudo -u www-data  $CAKE Server cacheFeed 1 all
 
     #FetchFeed: MISP/app/Console/cake Server fetchFeed [user_id] [feed_id|all|csv|text|misp]
-    echo "$STARTMSG $CAKE Server fetchFeed 1 all..." && $CAKE Server fetchFeed 1 all
+    echo "$STARTMSG $CAKE Server fetchFeed 1 all..." && sudo -u www-data  $CAKE Server fetchFeed 1 all
     # Finished
     echo "$STARTMSG [ $COUNTER ] Finished MISP-dockerized Cronjob at `date +%Y-%m-%d_%H:%M`... "
     sleep 3600

--- a/2.4.99-debian/files/entrypoint_cron.sh
+++ b/2.4.99-debian/files/entrypoint_cron.sh
@@ -8,7 +8,7 @@ CAKE="/var/www/MISP/app/Console/cake"
 
 
 # SLEEP 1h
-sleep 3600
+sleep 1800
 
 [ -z $AUTH_KEY ] && export AUTH_KEY=$(mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE -e "SELECT authkey FROM users;" | head -2|tail -1)
 
@@ -45,7 +45,7 @@ do
     #If you would like to automate tasks such as caching feeds or pulling from server instances, you can do it using the following command line tools. Simply execute the given commands via the command line / create cron jobs easily out of them.:
     #Pull: MISP/app/Console/cake Server pull [user_id] [server_id] [full|update]
 
-    echo "$STARTMSG $CAKE Server pull 1 update..." && sudo -u www-data $CAKE Server pull 1 update
+    echo "$STARTMSG $CAKE Server pull 1 update..." && sudo -u www-data $CAKE Server pull 1
 
     # CacheFeed: MISP/app/Console/cake Server cacheFeed [user_id] [feed_id|all|csv|text|misp]
     echo "$STARTMSG $CAKE Server cacheFeed 1 all..." && sudo -u www-data  $CAKE Server cacheFeed 1 all

--- a/2.4.99-debian/files/entrypoint_cron.sh
+++ b/2.4.99-debian/files/entrypoint_cron.sh
@@ -45,13 +45,13 @@ do
     #If you would like to automate tasks such as caching feeds or pulling from server instances, you can do it using the following command line tools. Simply execute the given commands via the command line / create cron jobs easily out of them.:
     #Pull: MISP/app/Console/cake Server pull [user_id] [server_id] [full|update]
 
-    echo "$STARTMSG $CAKE Server pull 1 update..." && $CAKE Server pull 1 update
+    echo "$STARTMSG $CAKE Server pull 1 update..." && sudo -u www-data $CAKE Server pull 1 update
 
     # CacheFeed: MISP/app/Console/cake Server cacheFeed [user_id] [feed_id|all|csv|text|misp]
-    echo "$STARTMSG $CAKE Server cacheFeed 1 all..." && $CAKE Server cacheFeed 1 all
+    echo "$STARTMSG $CAKE Server cacheFeed 1 all..." && sudo -u www-data  $CAKE Server cacheFeed 1 all
 
     #FetchFeed: MISP/app/Console/cake Server fetchFeed [user_id] [feed_id|all|csv|text|misp]
-    echo "$STARTMSG $CAKE Server fetchFeed 1 all..." && $CAKE Server fetchFeed 1 all
+    echo "$STARTMSG $CAKE Server fetchFeed 1 all..." && sudo -u www-data  $CAKE Server fetchFeed 1 all
     # Finished
     echo "$STARTMSG [ $COUNTER ] Finished MISP-dockerized Cronjob at `date +%Y-%m-%d_%H:%M`... "
     sleep 3600


### PR DESCRIPTION
## Changelog for bug.MDD148 - Fixing Bugs in entrypoint scripts for MISP-Server 2.4.97-99
### Update Informations 
The entrypoint_apache.sh script takes care of the settings of apache2 and the basic settings of MISP itself. 
The entrypoint_cron.sh script is our cronjob replacement.

### General Changes
No general changes were made.

### Fixes & Improvements
- Fixed in entrypoint_apache.sh script the way how we detect the MISP URL
- Fixed in entrypoint_cron.sh the execution user and change the repeat time from 1h to 0.5h.

### Detailed Changes
- Additionally to the MISP_FQDN we introduced MISP_URL
  MISP_FQDN is misp.example.com and MISP_URL is https://misp.example.com
- The Base initalization should be done after every restart.
  This means that on every container restart the baseurl, the database.php and the config.php are updated.
- We add the sudo command with user www-data to the cake command in entrypoint_cron.sh script. Therefore new events or files should be created as www-data and not as root user.