### PR TITLE
Bug/MDD-198: Fixing Gitlab CI to Build All Images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,6 @@ before_script:
   stage: build
   only: 
   - master
-  - bug/MDD-194
   script:
   - make -C .ci build v=$VERSION 
   - make -C .ci tags REPOURL=$CUSTOM_REGISTRY_URL
@@ -44,20 +43,20 @@ before_script:
 # For a cleaner Gitlab CI file include all subfolder which should be build:
 #
 include:
-  # - '2.4.nightly-ubuntu/.gitlab-ci.yml'
-  # - '2.4.88-ubuntu/.gitlab-ci.yml'
-  # - '2.4.89-ubuntu/.gitlab-ci.yml'
-  # - '2.4.90-ubuntu/.gitlab-ci.yml'
-  # - '2.4.91-ubuntu/.gitlab-ci.yml'
-  # - '2.4.92-ubuntu/.gitlab-ci.yml'
-  # - '2.4.93-ubuntu/.gitlab-ci.yml'
-  # - '2.4.94-ubuntu/.gitlab-ci.yml'
-  # - '2.4.95-ubuntu/.gitlab-ci.yml'
-  # - '2.4.96-ubuntu/.gitlab-ci.yml'
-  # - '2.4.97-debian/.gitlab-ci.yml'
-  # - '2.4.98-debian/.gitlab-ci.yml'
-  # - '2.4.99-debian/.gitlab-ci.yml'
-  # - '2.4.100-debian/.gitlab-ci.yml'
-  # - '2.4.101-debian/.gitlab-ci.yml'
-  # - '2.4.102-debian/.gitlab-ci.yml'
+  - '2.4.nightly-ubuntu/.gitlab-ci.yml'
+  - '2.4.88-ubuntu/.gitlab-ci.yml'
+  - '2.4.89-ubuntu/.gitlab-ci.yml'
+  - '2.4.90-ubuntu/.gitlab-ci.yml'
+  - '2.4.91-ubuntu/.gitlab-ci.yml'
+  - '2.4.92-ubuntu/.gitlab-ci.yml'
+  - '2.4.93-ubuntu/.gitlab-ci.yml'
+  - '2.4.94-ubuntu/.gitlab-ci.yml'
+  - '2.4.95-ubuntu/.gitlab-ci.yml'
+  - '2.4.96-ubuntu/.gitlab-ci.yml'
+  - '2.4.97-debian/.gitlab-ci.yml'
+  - '2.4.98-debian/.gitlab-ci.yml'
+  - '2.4.99-debian/.gitlab-ci.yml'
+  - '2.4.100-debian/.gitlab-ci.yml'
+  - '2.4.101-debian/.gitlab-ci.yml'
+  - '2.4.102-debian/.gitlab-ci.yml'
   - '2.4.103-debian/.gitlab-ci.yml'

--- a/2.4.93-ubuntu/.gitlab-ci.yml
+++ b/2.4.93-ubuntu/.gitlab-ci.yml
@@ -1,14 +1,14 @@
-build 2.4.93-debian:
+build 2.4.93-ubuntu:
   extends: .build
   variables:
-    VERSION: "2.4.93-debian"
+    VERSION: "2.4.93-ubuntu"
 
 
-test 2.4.93-debian:
+test 2.4.93-ubuntu:
   extends: .test
   variables:
-    VERSION: "2.4.93-debian"
+    VERSION: "2.4.93-ubuntu"
   only:
     changes:
-    - 2.4.93-debian/*
+    - 2.4.93-ubuntu/*
     

--- a/2.4.93-ubuntu/Dockerfile
+++ b/2.4.93-ubuntu/Dockerfile
@@ -323,7 +323,6 @@ RUN sudo -u www-data mkdir /var/www/MISP/.smime; \
 
 # Entrypoints
     COPY files/entrypoint_apache.sh /
-    COPY files/entrypoint_cron.sh /
     COPY files/entrypoint_mariadb.sh /
     COPY files/entrypoint_redis.sh /
     COPY files/entrypoint_rsyslog.sh /

--- a/2.4.93-ubuntu/Dockerfile
+++ b/2.4.93-ubuntu/Dockerfile
@@ -310,17 +310,6 @@ RUN sudo -u www-data mkdir /var/www/MISP/.smime; \
 # Copy patch File for MISP Events Page with additional Analyse Column
     COPY --chown=www-data:www-data files/var/www/MISP/app/View/Elements/Events/eventIndexTable.patch /
 
-# Syslog Server & rsyslog
-    #COPY files/etc/syslog-ng/syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
-    #COPY files/etc/rsyslog.d/rsyslog_custom.conf /etc/rsyslog.d/
-
-# HTML5 File uploader from http://www.matlus.com/html5-file-upload-with-progress/#codeListing6
-    #COPY files/ssl_upload.html /var/www/MISP/app/webconfig/
-
-# Postfix
-# Copy files to postfix container
-    COPY files/etc/postfix/* /etc/postfix/
-
 # I create this empty file to decide is the configuration completely new or not in the entrypoint_apache.sh
     RUN touch "/var/www/MISP/app/Config/NOT_CONFIGURED"
 
@@ -336,7 +325,6 @@ RUN sudo -u www-data mkdir /var/www/MISP/.smime; \
     COPY files/entrypoint_apache.sh /
     COPY files/entrypoint_cron.sh /
     COPY files/entrypoint_mariadb.sh /
-    COPY files/entrypoint_postfix.sh /
     COPY files/entrypoint_redis.sh /
     COPY files/entrypoint_rsyslog.sh /
     COPY files/entrypoint_workers.sh /


### PR DESCRIPTION
## Bug/MDD-198: Fixing Gitlab CI to Build All Images
### Update Information
This release fixed small bugs in Gitlab CI files.
### General Changes
The general Gitlab CI files was changed. We activated all images to build in our local Gitlab CI.
### Fixes and Improvements
- Changed Main Gitlab CI file
- Changed 2.4.93 Gitlab CI file
- Changed 2.4.93 Dockerfile to remove all not existing files
### Detailed Changes
- Changed Main Gitlab CI file
   Activate all disabled images to build.
- Changed 2.4.93 Gitlab CI file
  Fix typos in the 2.4.93 Gitlab CI file the base is not debian it is ubuntu.
- Changed 2.4.93 Dockerfile to remove all not existing files
   We copy the content from 2.4.103 Docker container, but as we create 2.4.93 we had no extra postfix installed.