### PR TITLE
Bug/MDD 199: Repair Global 'tagging.sh' Script

### DIFF
--- a/.ci/03_tagging.sh
+++ b/.ci/03_tagging.sh
@@ -63,7 +63,7 @@ SOURCE_REPO="not2push"
 
 
 # Lookup to all build versions of the current docker container
-ALL_BUILD_DOCKER_VERSIONS=$(docker images --format '{{.Repository}}={{.Tag}}'|grep $CONTAINER_NAME |cut -d = -f 2)
+ALL_BUILD_DOCKER_VERSIONS=$(docker images --format '{{.Repository}}={{.Tag}}'|grep "$CONTAINER_NAME" | grep "$SOURCE_REPO" |cut -d = -f 2)
 
 # Tag Latest + Version Number
 for i in $ALL_BUILD_DOCKER_VERSIONS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,9 @@ before_script:
   - master  
   script:
   - make -C .ci build v=$VERSION
+  - make -C .ci tags REPOURL=$CUSTOM_REGISTRY_URL
+  - make -C .ci tags REPOURL=$DOCKER_SLUG
+  
 
 .build:
   stage: build

--- a/2.4.nightly-ubuntu/.gitlab-ci.yml
+++ b/2.4.nightly-ubuntu/.gitlab-ci.yml
@@ -2,3 +2,12 @@ build 2.4.nightly-ubuntu:
   extends: .build
   variables:
     VERSION: "2.4.nightly-ubuntu"
+
+test 2.4.nightly-ubuntu:
+  extends: .test
+  variables:
+    VERSION: "2.4.nightly-ubuntu"
+  only:
+    changes:
+    - 2.4.nightly-ubuntu/*
+    


### PR DESCRIPTION
## Bug/MDD-199: Repair Global 'tagging.sh' Script
### Update Information
This release fixed a bug in `tagging.sh` script.
### General Changes
The general `tagging.sh` script was changed.
There are no user actions required.
### Fixes and Improvements
- Restricted Docker image souce repository tags to source repository not2push
- Added test Gitlab CI job for 2.4.nightly-ubuntu
- Added tag commands to Gitlab CI test job
### Detailed Changes
- Restricted Docker image souce repository tags to source repository not2push
   The `tagging.sh` save all tags which are pass to the current container name. But this is problematic for the case that we tag first for the one repository and then for the second. Therefore there are new tags which not exists for 'not2push' repository but exists for an custom repository. This runs into an error. Which was fixed now.
- Added test Gitlab CI job for 2.4.nightly-ubuntu
   The 2.4.nightly-ubuntu had no second Gitlab CI job for test, only the build CI job. Therefore we added this test.
- Added tag commands to Gitlab CI test job
   The tag command was not tested at test CI job. Now we fixed this.